### PR TITLE
Improve hospital number picking, and use redirect

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,9 +7,27 @@ class ApplicationController < ActionController::Base
   end
 
   def specify_hospital_number
-    self.current_hospital_number = params[:hospital_number]
-    flash.now[:success] = "Hospital number #{current_hospital_number} selected"
-    render action: :index
+    assign_current_hospital_number
+    build_hospital_number_flash_message
+    redirect_to action: :index
+  end
+
+
+  private
+
+  def assign_current_hospital_number
+    self.current_hospital_number = nil
+    if params[:hospital_number].present?
+      self.current_hospital_number = params[:hospital_number]
+    end
+  end
+
+  def build_hospital_number_flash_message
+    if current_hospital_number
+      flash[:success] = "Hospital number #{current_hospital_number} selected"
+    else
+      flash[:notice] = "Hospital number cleared"
+    end
   end
 
 end

--- a/features/landing_page/user_specifies_hospital_number.feature
+++ b/features/landing_page/user_specifies_hospital_number.feature
@@ -5,5 +5,13 @@ Scenario: I visit the landing page, and specify my hospital number
   Then I should see "Enter hospital number"
   When I enter hospital number "123456"
   And I press "Set"
-  Then I should see a success message saying "Hospital number 123456 selected"
+  Then I should see a success flash message saying "Hospital number 123456 selected"
   And I should see "(currently 123456)"
+
+Scenario: I visit the landing page, and clear my hospital number
+  When I go to the app's home page
+  Then I should see "Enter hospital number"
+  When I enter hospital number ""
+  And I press "Set"
+  Then I should see a notice flash message saying "Hospital number cleared"
+  And I should not see "(currently"

--- a/features/step_definitions/landing_page_steps.rb
+++ b/features/step_definitions/landing_page_steps.rb
@@ -1,26 +1,3 @@
-When(/^I go to the app's home page$/) do
-  visit "/"
-end
-
-Then(/^I should see "([^"]*)"$/) do |content|
-  expect(page).to have_content content
-end
-
-Then(/^I should not see "([^"]*)"$/) do |content|
-  expect(page).to_not have_content content
-end
-
 When(/^I enter hospital number "([^"]*)"$/) do |num|
   fill_in "hospital_number", with: num
 end
-
-When(/^I press "([^"]*)"$/) do |button_text|
-  click_button button_text
-end
-
-Then(/^I should see a (success|notice|failure) flash message saying "([^"]*)"$/) do |flash_type, message_text|
-  within ".flash.flash-message.#{flash_type}" do
-    expect(page).to have_content message_text
-  end
-end
-

--- a/features/step_definitions/landing_page_steps.rb
+++ b/features/step_definitions/landing_page_steps.rb
@@ -6,6 +6,10 @@ Then(/^I should see "([^"]*)"$/) do |content|
   expect(page).to have_content content
 end
 
+Then(/^I should not see "([^"]*)"$/) do |content|
+  expect(page).to_not have_content content
+end
+
 When(/^I enter hospital number "([^"]*)"$/) do |num|
   fill_in "hospital_number", with: num
 end
@@ -14,8 +18,9 @@ When(/^I press "([^"]*)"$/) do |button_text|
   click_button button_text
 end
 
-Then(/^I should see a success message saying "([^"]*)"$/) do |message_text|
-  within ".flash-message.success" do
+Then(/^I should see a (success|notice|failure) flash message saying "([^"]*)"$/) do |flash_type, message_text|
+  within ".flash.flash-message.#{flash_type}" do
     expect(page).to have_content message_text
   end
 end
+

--- a/features/step_definitions/shared_steps.rb
+++ b/features/step_definitions/shared_steps.rb
@@ -1,0 +1,21 @@
+When(/^I go to the app's home page$/) do
+  visit "/"
+end
+
+Then(/^I should see "([^"]*)"$/) do |content|
+  expect(page).to have_content content
+end
+
+Then(/^I should not see "([^"]*)"$/) do |content|
+  expect(page).to_not have_content content
+end
+
+Then(/^I should see a (success|notice|failure) flash message saying "([^"]*)"$/) do |flash_type, message_text|
+  within ".flash.flash-message.#{flash_type}" do
+    expect(page).to have_content message_text
+  end
+end
+
+When(/^I press "([^"]*)"$/) do |button_text|
+  click_button button_text
+end


### PR DESCRIPTION
READY

Allows clearing the hospital number, and redirects after POST to avoid unfriendly "do you want to re-submit" messages in the browser if user refreshes page.