### PR TITLE
Use more real estate for data entry when available

### DIFF
--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -18,3 +18,7 @@ span.number-label {
 table.isolate-data-entry tbody tr td.not-too-small {
   min-width: 6em;
 }
+
+body.shipments.data_entry div.container, body.shipments.save_isolate_data div.container {
+  width: 98%;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,10 @@
 class ApplicationController < ActionController::Base
+
   protect_from_forgery with: :exception
 
   include SessionHelper
+
+  before_action :assign_body_css_classes
 
   def index
   end
@@ -28,6 +31,10 @@ class ApplicationController < ActionController::Base
     else
       flash[:notice] = "Hospital number cleared"
     end
+  end
+
+  def assign_body_css_classes
+    @body_css_classes = "#{params[:controller]} #{params[:action]}"
   end
 
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,7 +7,7 @@
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
 
-  %body
+  %body{class: @body_css_classes}
     .container
       = render partial: "layouts/navbar"
       = render partial: "layouts/flash_messages"


### PR DESCRIPTION
READY

Assigns CSS classes to the `<body>` based on controller and action names, then has some CSS for the isolate data entry screens to better use the  available width.

![screen shot 2016-08-09 at 6 08 38 am](https://cloud.githubusercontent.com/assets/683970/17514396/04ff1562-5df8-11e6-9f19-13a0676cff94.png)
