### PR TITLE
Improve hospital report database efficiency

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -3,18 +3,24 @@ class Report
   def self.hospital_stats
     hsh = Hash.new(0)
     hospital_stats_rows.each do |row|
-      hospital_number, objective_code, objective_code_shipment_count, objective_code_isolate_count = row
+      hospital_number, objective_code, shipment_count, isolate_count = row
 
-      hsh["shipment_info_#{hospital_number}"] += objective_code_shipment_count
-      hsh["shipment_info"] += objective_code_shipment_count
-
-      hsh["objective_info_#{objective_code}_#{hospital_number}"] += objective_code_shipment_count
-      hsh["objective_info_#{objective_code}"] += objective_code_shipment_count
-
-      hsh["isolate_info_#{objective_code}_#{hospital_number}"] += objective_code_isolate_count
-      hsh["isolate_info_#{objective_code}"] += objective_code_isolate_count
-      hsh["isolate_info_total_#{hospital_number}"] += objective_code_isolate_count
-      hsh["isolate_info_total"] += objective_code_isolate_count
+      if hospital_number.blank? && objective_code.blank?
+        # the grand total for shipments and isolates row
+        hsh["shipment_info"]      = shipment_count
+        hsh["isolate_info_total"] = isolate_count
+      elsif objective_code.blank?
+        # a total row for shipments and isolates for a hospital
+        hsh["shipment_info_#{hospital_number}"]      = shipment_count
+        hsh["isolate_info_total_#{hospital_number}"] = isolate_count
+      elsif hospital_number.blank?
+        # a total row for shipments and isolates
+        hsh["objective_info_#{objective_code}"] = shipment_count
+        hsh["isolate_info_#{objective_code}"]   = isolate_count
+      else
+        hsh["objective_info_#{objective_code}_#{hospital_number}"] = shipment_count
+        hsh["isolate_info_#{objective_code}_#{hospital_number}"]   = isolate_count
+      end
     end
     hsh
   end
@@ -34,8 +40,7 @@ COUNT(DISTINCT shipments.id) AS objective_code_shipment_count,
 COUNT(isolates.*) AS objective_code_isolate_count
 FROM shipments
 LEFT OUTER JOIN isolates ON isolates.shipment_id = shipments.id
-GROUP BY 1,2
-ORDER BY 1,2
+GROUP BY CUBE( hospital_number, objective_code )
 END_OF_SQL
     ActiveRecord::Base.connection.select_rows sql
   end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -2,42 +2,42 @@ class Report
 
   def self.hospital_stats
     hsh = Hash.new(0)
+    hospital_stats_rows.each do |row|
+      hospital_number, objective_code, objective_code_shipment_count, objective_code_isolate_count = row
 
-    shipment_hospital_numbers.each do |hospital_number|
-      # shipment count for hospital
-      hsh["shipment_info_#{hospital_number}"] = Shipment.where(hospital_number: hospital_number).count
+      hsh["shipment_info_#{hospital_number}"] += objective_code_shipment_count
+      hsh["shipment_info"] += objective_code_shipment_count
 
-      # objective counts for hospital
-      %w(A B Q).each do |objective_code|
-        hsh["objective_info_#{objective_code}_#{hospital_number}"] = Shipment.where(hospital_number: hospital_number, objective_code: objective_code).count
-      end
+      hsh["objective_info_#{objective_code}_#{hospital_number}"] += objective_code_shipment_count
+      hsh["objective_info_#{objective_code}"] += objective_code_shipment_count
 
-      # isolate counts for hospital
-      %w(A B Q).each do |objective_code|
-        hsh["isolate_info_#{objective_code}_#{hospital_number}"] = Shipment.joins(:isolates).where(hospital_number: hospital_number, objective_code: objective_code).count
-      end
-      hsh["isolate_info_total_#{hospital_number}"] = Shipment.joins(:isolates).where(hospital_number: hospital_number).count
+      hsh["isolate_info_#{objective_code}_#{hospital_number}"] += objective_code_isolate_count
+      hsh["isolate_info_#{objective_code}"] += objective_code_isolate_count
+      hsh["isolate_info_total_#{hospital_number}"] += objective_code_isolate_count
+      hsh["isolate_info_total"] += objective_code_isolate_count
     end
-
-    # shipment count for ALL hospitals
-    hsh["shipment_info"] = Shipment.count
-
-    # objective counts for ALL hospitals
-    %w(A B Q).each do |objective_code|
-      hsh["objective_info_#{objective_code}"] = Shipment.where(objective_code: objective_code).count
-    end
-
-    # isolate counts for ALL hospitals
-    %w(A B Q).each do |objective_code|
-      hsh["isolate_info_#{objective_code}"] = Shipment.joins(:isolates).where(objective_code: objective_code).count
-    end
-    hsh["isolate_info_total"] = Shipment.joins(:isolates).count
-
     hsh
   end
 
   def self.shipment_hospital_numbers
     Shipment.distinct.pluck(:hospital_number).sort
+  end
+
+
+  private
+
+  def self.hospital_stats_rows
+    sql = <<-END_OF_SQL
+SELECT hospital_number,
+shipments.objective_code AS objective_code,
+COUNT(DISTINCT shipments.id) AS objective_code_shipment_count,
+COUNT(isolates.*) AS objective_code_isolate_count
+FROM shipments
+LEFT OUTER JOIN isolates ON isolates.shipment_id = shipments.id
+GROUP BY 1,2
+ORDER BY 1,2
+END_OF_SQL
+    ActiveRecord::Base.connection.select_rows sql
   end
 
 end

--- a/spec/factories/isolates.rb
+++ b/spec/factories/isolates.rb
@@ -1,0 +1,16 @@
+FactoryGirl.define do
+
+  factory :isolate do
+    age         50
+    nosocomial  false
+    icu         true
+    association :shipment
+
+    factory :random_isolate do
+      age        { rand(125)  }
+      nosocomial { [true, false].sample }
+      icu        { [true, false].sample }
+    end
+  end
+
+end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -5,6 +5,51 @@ RSpec.describe Report, type: :model do
       stats = Report.hospital_stats
       expect(stats).to be_a Hash
     end
+
+    it "returns the expected values from the database" do
+      %w(A B Q).each_with_index do |objective_code, idx|
+        s1 = FactoryGirl.create :shipment, hospital_number: "1234567", objective_code: objective_code
+        s2 = FactoryGirl.create :shipment, hospital_number: "8675309", objective_code: objective_code
+        isolate_qty = idx + 1
+        isolate_qty.times do
+          FactoryGirl.create :random_isolate, shipment: s1
+          FactoryGirl.create :random_isolate, shipment: s2
+        end
+      end
+
+      stats = Report.hospital_stats
+
+      expect(stats["shipment_info_1234567"]).to eq 3
+      expect(stats["shipment_info_8675309"]).to eq 3
+      expect(stats["shipment_info"]).to eq 6
+
+      expect(stats["objective_info_A_1234567"]).to eq 1
+      expect(stats["objective_info_B_1234567"]).to eq 1
+      expect(stats["objective_info_Q_1234567"]).to eq 1
+
+      expect(stats["objective_info_A_8675309"]).to eq 1
+      expect(stats["objective_info_B_8675309"]).to eq 1
+      expect(stats["objective_info_Q_8675309"]).to eq 1
+
+      expect(stats["isolate_info_A_1234567"]).to eq 1
+      expect(stats["isolate_info_B_1234567"]).to eq 2
+      expect(stats["isolate_info_Q_1234567"]).to eq 3
+      expect(stats["isolate_info_total_1234567"]).to eq 6
+
+      expect(stats["isolate_info_A_8675309"]).to eq 1
+      expect(stats["isolate_info_B_8675309"]).to eq 2
+      expect(stats["isolate_info_Q_8675309"]).to eq 3
+      expect(stats["isolate_info_total_8675309"]).to eq 6
+
+      expect(stats["objective_info_A"]).to eq 2
+      expect(stats["objective_info_B"]).to eq 2
+      expect(stats["objective_info_Q"]).to eq 2
+
+      expect(stats["isolate_info_A"]).to eq 2
+      expect(stats["isolate_info_B"]).to eq 4
+      expect(stats["isolate_info_Q"]).to eq 6
+      expect(stats["isolate_info_total"]).to eq 12
+    end
   end
 
 end


### PR DESCRIPTION
READY though it will fail at TravisCI as they have not yet provided full support for Postgresql 9.5 (required for the ROLLUP-related functions).

Does away with the N+1 query situation.  Still 2 queries - one grabs distinct hospital numbers, the other grabs the report data.  Definitely possible to optimize that first one away, either by collecting unique hospital numbers from the report data hash or by utilizing only the report rows without the intermediate hash (e.g. rendering the report data in a more raw format, closer to what the db engine returns).
